### PR TITLE
A minor extension to the API and other minor changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .bundle
 Gemfile.lock
 pkg/*
+*.swp
+.rvmrc

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,0 @@
---color --drb --debugger

--- a/lib/cicero.rb
+++ b/lib/cicero.rb
@@ -27,25 +27,17 @@ module Cicero
     words
   end
 
-  def self.words(number = 1)
-    text = full
-    str = ""
-    number.times{ str += "#{splitter(" ")} "}
-    str.strip.gsub(/[,.;'"!?]/,'')
+  def self.words(n = 1)
+    (1..n).reduce("") do |s,j|
+      s << "#{splitter2(" ")} "
+    end.strip.gsub(/[,.;'"!?]/,'')
   end
 
   def self.sentence
     sentences
   end
 
-  def self.sentences(number = 1)
-    text = full
-    str = ""
-    number.times { str += "#{splitter(". ").strip}. "}
-    str.strip
-  end
-
-  def self.sents(n = 1)
+  def self.sentences(n = 1)
     (1..n).reduce("") do |s,j|
       s << "#{splitter2(". ").strip}. "
     end
@@ -72,6 +64,6 @@ module Cicero
   end
 
   def self.splitter2( on )
-    full.split(". ").cicero_rand 
+    full.split( on ).cicero_rand 
   end
 end

--- a/lib/cicero.rb
+++ b/lib/cicero.rb
@@ -1,5 +1,6 @@
-require "cicero/version"
-require "cicero/cicero_text"
+# encoding: UTF-8
+
+require_relative "./cicero/cicero_text.rb"
 
 module Cicero
   
@@ -45,6 +46,13 @@ module Cicero
 
   def self.paragraph
     self.paragraphs
+  end
+  
+  require_relative "./cicero/ext/Array.rb"
+  def self.paras(n = 1 )
+    (1..n).reduce("") do |s,j|
+      s << (0..7).inject([]){|mem,i| i == 7 ? mem : mem << full.split(". ").cicero_rand.strip }.join(". ")
+    end
   end
 
   def self.paragraphs(number = 1)

--- a/lib/cicero.rb
+++ b/lib/cicero.rb
@@ -28,7 +28,7 @@ module Cicero
   end
 
   def self.words(n = 1)
-    (1..n).reduce("") do |s,j|
+    (1..n).reduce("") do |s,_|
       s << "#{splitter2(" ")} "
     end.strip.gsub(/[,.;'"!?]/,'')
   end
@@ -38,7 +38,7 @@ module Cicero
   end
 
   def self.sentences(n = 1)
-    (1..n).reduce("") do |s,j|
+    (1..n).reduce("") do |s,_|
       s << "#{splitter2(". ").strip}. "
     end
   end
@@ -48,7 +48,7 @@ module Cicero
   end
   
   def self.paragraphs(n = 1 )
-    (1..n).reduce("") do |s,j|
+    (1..n).reduce("") do |s,_|
       s << (0..7).inject([]){|mem,i| i == 7 ? mem : mem << splitter2(". ")}.map{|x| x.strip }.join(". ")
     end
   end

--- a/lib/cicero.rb
+++ b/lib/cicero.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 require_relative "./cicero/cicero_text.rb"
+require_relative "./cicero/ext/Array.rb"
 
 module Cicero
   
@@ -29,7 +30,7 @@ module Cicero
   def self.words(number = 1)
     text = full
     str = ""
-    number.times{ str += "#{text.split(' ')[rand(text.split(' ').size) - 1]} "}
+    number.times{ str += "#{splitter(" ")} "}
     str.strip.gsub(/[,.;'"!?]/,'')
   end
 
@@ -40,18 +41,23 @@ module Cicero
   def self.sentences(number = 1)
     text = full
     str = ""
-    number.times { str += "#{text.split('. ')[rand(text.split('. ').size) - 1].strip}. "}
+    number.times { str += "#{splitter(". ").strip}. "}
     str.strip
+  end
+
+  def self.sents(n = 1)
+    (1..n).reduce("") do |s,j|
+      s << "#{splitter2(". ").strip}. "
+    end
   end
 
   def self.paragraph
     self.paragraphs
   end
   
-  require_relative "./cicero/ext/Array.rb"
   def self.paragraphs(n = 1 )
     (1..n).reduce("") do |s,j|
-      s << (0..7).inject([]){|mem,i| i == 7 ? mem : mem << full.split(". ").cicero_rand.strip }.join(". ")
+      s << (0..7).inject([]){|mem,i| i == 7 ? mem : mem << splitter2(". ")}.map{|x| x.strip }.join(". ")
     end
   end
 
@@ -61,4 +67,11 @@ module Cicero
     CiceroText.text(@locale)
   end
 
+  def self.splitter( on )
+    full.split(on)[rand(full.split(on).size) - 1]
+  end
+
+  def self.splitter2( on )
+    full.split(". ").cicero_rand 
+  end
 end

--- a/lib/cicero.rb
+++ b/lib/cicero.rb
@@ -49,21 +49,10 @@ module Cicero
   end
   
   require_relative "./cicero/ext/Array.rb"
-  def self.paras(n = 1 )
+  def self.paragraphs(n = 1 )
     (1..n).reduce("") do |s,j|
       s << (0..7).inject([]){|mem,i| i == 7 ? mem : mem << full.split(". ").cicero_rand.strip }.join(". ")
     end
-  end
-
-  def self.paragraphs(number = 1)
-    text = full
-    str= ""
-    number.times do 
-      7.times { str += "#{text.split('. ')[rand(text.split('. ').size) - 1].strip}. "}
-      str.strip!
-      str += "\n"
-    end
-    str
   end
 
 

--- a/lib/cicero.rb
+++ b/lib/cicero.rb
@@ -12,6 +12,10 @@ module Cicero
   def self.locale
     @locale
   end
+
+  def self.locales
+    CiceroText.locales
+  end
   
   def self.full_text
     text = full

--- a/lib/cicero/cicero_text.rb
+++ b/lib/cicero/cicero_text.rb
@@ -75,21 +75,21 @@ Ler. Como a aqui. Nós sempre, para seus seguidores! A menos que o telefone era 
 Leia mais perguntas, o autor de Sobre, consectetuer que, clicando aqui, e depois cozido. Leia mais itens. Não há visualização, às vezes menos, eu não vou, vai aqui, e nenhum dos dois. Mantenha seus recursos velhice e administrar, e é a qualidade mais fácil. Gadget é a descrição curta ou longa que, mais e mais do que não. Eu entendo e eu ILGA-ligula. Clique aqui. Operacional, e que o luto não mais, os membros pé aqui na terça-feira, ou massa do arco você precisa aqui. Nós elit. Mantenha seus recursos velhice e administrar, e é a qualidade mais fácil. Nós SEM eros, abre-se para a vantagem de seu tempo para você. Sejam bem-vindos. Este é um leão aqui, nem beber, para enfeitar e da Internet no centro. Sapatos ponto de vista, um leão. E-mail e solicite a escola desenvolver o seu currículo por si só Adicione a sua resposta. Acceptrange contato. 
 Leia mais tardar, arco e, fazer mais. Mas agora, lagos, Legends, nos veículos, você precisa da questão. Por enquanto, consectetuer euismod. Início No More. Vamos correr mais. Nenhum homem sábio: * Senha: ou mais, que a sua aqui, a política do seu. Mas até o mais suas idéias para todos. Nós, e receitas mais e mais. Nós é. É mais do que fácil você ter uma idéia. Até mais meu estilo que é, a, convallis site de seu próprio país. Adicione seu nome aqui. Resultados do nosso e-News aqui. Nós livre. Clique aqui. Consectetuer mais do que o seu preço. Aqui não existe mais, eu nem Vinhos elemento Espíritos não, o invisível. Leia mais.}.gsub("\n",'')
 
-  def self.text(locale = 'LA')
-    case locale.upcase
-    when 'ES'
-      ES
-    when 'EN'
-      EN
-    when 'FR'
-      EN
-    when 'IT'
-      LA
-    when 'PT'
-      LA
-    else
-      LA
+  def self.ipsums # my own little joke, ipsum means self in Latin :)
+    if @ipsums.nil?
+      @ipsums = Hash[ 'ES', ES, 'EN', EN, 'FR', FR, 'PT', PT, 'LA', LA ]
+      @ipsums.default = LA
     end
+    @ipsums
+  end
+
+
+  def self.locales
+    CiceroText.ipsums.keys
+  end
+
+  def self.text(locale = 'LA')
+    CiceroText.ipsums[locale.upcase]
   end
 
 end

--- a/lib/cicero/ext/Array.rb
+++ b/lib/cicero/ext/Array.rb
@@ -1,0 +1,9 @@
+# encoding: UTF-8
+
+class Array
+
+  def cicero_rand
+    self[Kernel.rand(length)]
+  end
+
+end

--- a/spec/benchmarks.rb
+++ b/spec/benchmarks.rb
@@ -1,5 +1,7 @@
 # encoding: UTF-8
 
+# Benchmarks for paragraphs method prior to commit 0cee2f720ed98caea5f165f48a3d53eba727bb71
+
 require_relative "../lib/cicero.rb"
 require "benchmark"
 

--- a/spec/benchmarks.rb
+++ b/spec/benchmarks.rb
@@ -5,7 +5,7 @@
 require_relative "../lib/cicero.rb"
 require "benchmark"
 
-T= 1000
+T= 10000
 r = []
 max = 7
 T.times {|_| r << ( 1 + rand( max ) ) }
@@ -17,12 +17,11 @@ puts T.class
 
 Benchmark.bm do |b|
 
-  b.report( "orig " ) do
-    T.times {|i| Cicero.paragraphs( R[i] ) }
+  b.report( "orig s " ) do
+    T.times {|i| Cicero.sentences( R[i] ) }
   end
     
-  b.report( 'new!' ) do
-    T.times {|i| Cicero.paras( R[i] ) }
+  b.report( 'new! s' ) do
+    T.times {|i| Cicero.sents( R[i] ) }
   end
-
 end

--- a/spec/benchmarks.rb
+++ b/spec/benchmarks.rb
@@ -1,0 +1,26 @@
+# encoding: UTF-8
+
+require_relative "../lib/cicero.rb"
+require "benchmark"
+
+T= 1000
+r = []
+max = 7
+T.times {|_| r << ( 1 + rand( max ) ) }
+R = r
+r = nil
+
+puts T.class
+
+
+Benchmark.bm do |b|
+
+  b.report( "orig " ) do
+    T.times {|i| Cicero.paragraphs( R[i] ) }
+  end
+    
+  b.report( 'new!' ) do
+    T.times {|i| Cicero.paras( R[i] ) }
+  end
+
+end

--- a/spec/spec/cicero_spec.rb
+++ b/spec/spec/cicero_spec.rb
@@ -95,19 +95,6 @@ describe Cicero do
     end
   end
 
-  describe '#paras' do
-    context 'With no parameters' do
-      it 'Returns a single paragraph' do
-        Cicero.paras.split('. ').size.should eql 7
-      end
-    end
-    context 'With parameters' do
-      it "Returns 'n' paragraphs" do
-        Cicero.paragraphs(3).split('. ').size.should eql (19)
-      end
-    end
-  end
-
   describe '#paragraphs' do
     context 'With no parameters' do
       it 'Returns a single paragraph' do

--- a/spec/spec/cicero_spec.rb
+++ b/spec/spec/cicero_spec.rb
@@ -95,6 +95,19 @@ describe Cicero do
     end
   end
 
+  describe '#paras' do
+    context 'With no parameters' do
+      it 'Returns a single paragraph' do
+        Cicero.paras.split('. ').size.should eql 7
+      end
+    end
+    context 'With parameters' do
+      it "Returns 'n' paragraphs" do
+        Cicero.paragraphs(3).split('. ').size.should eql (19)
+      end
+    end
+  end
+
   describe '#paragraphs' do
     context 'With no parameters' do
       it 'Returns a single paragraph' do

--- a/spec/spec/cicero_spec.rb
+++ b/spec/spec/cicero_spec.rb
@@ -19,6 +19,14 @@ describe Cicero do
     end
   end
 
+  describe "locales" do
+    subject { Cicero.locales }
+    it { should_not be_nil }
+    it { should be_a_kind_of Array }
+    it { should_not be_empty }
+    it { should include 'LA' }
+  end
+
   describe "#full_text" do
     it 'Returns the full lorem ipsum text' do
       Cicero.full_text.should eql(CiceroText::LA)

--- a/spec/spec/cicero_text_spec.rb
+++ b/spec/spec/cicero_text_spec.rb
@@ -1,6 +1,33 @@
-require 'spec_helper'
+# encoding: UTF-8
+require_relative '../spec_helper.rb'
 
 describe CiceroText do
+
+  describe "locales" do
+    subject { CiceroText.locales }
+    it { should_not be_nil }
+    it { should be_a_kind_of Array }
+    it { should_not be_empty }
+    it { should include 'LA' }
+  end
+
+  describe "ipsums" do
+    subject { CiceroText.ipsums }
+    it { should_not be_nil }
+    it { should be_a_kind_of Hash }
+    it { should_not be_empty }
+    context "When given a locale" do
+      context "That is in the hash" do
+        subject { CiceroText.ipsums['EN'] }
+        it { should eql CiceroText::EN }
+      end
+      context "That is not in the hash" do
+        subject { CiceroText.ipsums['AA'] }
+        it { should eql CiceroText::LA }
+      end
+    end
+  end
+
   describe "#text" do
     context 'With locale parameter' do
       it 'Returns the desired verision' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,9 @@
-require 'rubygems'
-require 'bundler/setup'
-require 'cicero/cicero_text'
+# encoding: UTF-8
 
-require 'cicero' # and any other gems you need
+require "rspec"
+require_relative '../lib/cicero/cicero_text.rb'
+
+require_relative '../lib/cicero.rb' # and any other gems you need
 
 RSpec.configure do |config|
 end


### PR DESCRIPTION
Hello,

I wanted to use Cicero for testing but with randomly chosen locales, so I made a few changes to the code to make it easier for me.
- I've put the locales and the ipsums into a hash and added some methods for accessing it to the public API
- I've changed the algorithm for the `words`, `sentences` and `paragraphs` methods, as an exercise. I benchmarked it and they're about twice as fast, but probably more cryptic. You win some, you lose some :)
- I removed some Rails specific stuff from the specs. I don't use Rails and it was getting in my way.
- There's an Array class extension in lib/cicero/ext

Anything else is just stylistic. I've added some specs, and everything passes. Feel free to take whatever you think is useful. Thanks for sharing the code/gem!

Regards,
Iain
